### PR TITLE
Client with support for "get pages by type" and "process page request" endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ group :development do
   gem 'juwelier', '~> 2.1.0'
   gem 'webmock', '~> 3.4'
   gem 'faker', '~> 1.9'
+  gem 'pry-byebug', '~> 3.6'
+  gem 'faraday-detailed_logger', '~> 2.1', '>= 2.1.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem 'rspec', '>= 0'
   gem 'juwelier', '~> 2.1.0'
   gem 'webmock', '~> 3.4'
+  gem 'faker', '~> 1.9'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source "https://rubygems.org"
 
+gem 'faraday', '~> 0.15'
+
 group :development do
   gem 'rspec', '>= 0'
   gem 'juwelier', '~> 2.1.0'
+  gem 'webmock', '~> 3.4'
 end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # engaging-networks-rest
 Client gem for the ENS API to Engaging Networks
+
+## Install
+
+`gem install engaging-networks-rest`
+
+## Usage
+
+```
+client = EngagingNetworksRest.new(api_key: 'YOUR API KEY HERE')
+
+# get pages by type
+pages = client.pages(type: 'dcf', status: 'live')
+
+# process a page request
+response = client.process_page_request(page_id: 12345, body: {supporter: {first_name: 'Alice'}})
+```
+
+The client will call authentication endpoint behind the scenes the first time it makes a request.
+Currently, it does not attempt to check if its token is still valid for later requests.
+It is possible to force re-authentication with `client.authenticate!`.

--- a/engaging-networks-rest.gemspec
+++ b/engaging-networks-rest.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |s|
     "engaging-networks-rest.gemspec",
     "lib/engaging_networks_rest.rb",
     "lib/engaging_networks_rest/client.rb",
+    "lib/engaging_networks_rest/client/pages.rb",
+    "spec/client/pages_spec.rb",
     "spec/client_spec.rb",
     "spec/spec_helper.rb"
   ]
@@ -47,17 +49,20 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
       s.add_development_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
       s.add_development_dependency(%q<webmock>.freeze, ["~> 3.4"])
+      s.add_development_dependency(%q<faker>.freeze, ["~> 1.9"])
     else
       s.add_dependency(%q<faraday>.freeze, ["~> 0.15"])
       s.add_dependency(%q<rspec>.freeze, [">= 0"])
       s.add_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
       s.add_dependency(%q<webmock>.freeze, ["~> 3.4"])
+      s.add_dependency(%q<faker>.freeze, ["~> 1.9"])
     end
   else
     s.add_dependency(%q<faraday>.freeze, ["~> 0.15"])
     s.add_dependency(%q<rspec>.freeze, [">= 0"])
     s.add_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
     s.add_dependency(%q<webmock>.freeze, ["~> 3.4"])
+    s.add_dependency(%q<faker>.freeze, ["~> 1.9"])
   end
 end
 

--- a/engaging-networks-rest.gemspec
+++ b/engaging-networks-rest.gemspec
@@ -29,7 +29,10 @@ Gem::Specification.new do |s|
     "Rakefile",
     "VERSION",
     "engaging-networks-rest.gemspec",
-    "lib/engaging_networks_rest.rb"
+    "lib/engaging_networks_rest.rb",
+    "lib/engaging_networks_rest/client.rb",
+    "spec/client_spec.rb",
+    "spec/spec_helper.rb"
   ]
   s.homepage = "http://github.com/controlshift/engaging-networks-rest".freeze
   s.licenses = ["MIT".freeze]
@@ -40,15 +43,21 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<faraday>.freeze, ["~> 0.15"])
       s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
       s.add_development_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
+      s.add_development_dependency(%q<webmock>.freeze, ["~> 3.4"])
     else
+      s.add_dependency(%q<faraday>.freeze, ["~> 0.15"])
       s.add_dependency(%q<rspec>.freeze, [">= 0"])
       s.add_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
+      s.add_dependency(%q<webmock>.freeze, ["~> 3.4"])
     end
   else
+    s.add_dependency(%q<faraday>.freeze, ["~> 0.15"])
     s.add_dependency(%q<rspec>.freeze, [">= 0"])
     s.add_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
+    s.add_dependency(%q<webmock>.freeze, ["~> 3.4"])
   end
 end
 

--- a/example.rb
+++ b/example.rb
@@ -1,0 +1,32 @@
+$LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
+
+require 'engaging_networks_rest'
+require 'faraday/detailed_logger'
+require 'byebug'
+
+def instrument_connection_with_extended_logging(client)
+  default_options = {
+    headers: {
+      'Accept' => "application/json;q=0.1",
+      'Accept-Charset' => "utf-8"
+    }
+  }
+
+  faraday_builder = ->(faraday) do
+    faraday.response :detailed_logger
+    faraday.adapter Faraday.default_adapter
+  end
+
+  instrumented_connection = Faraday.new(
+    default_options.merge(url: "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}"),
+    &faraday_builder
+  )
+  client.instance_variable_set(:@connection, instrumented_connection)
+end
+
+client = EngagingNetworksRest.new(api_key: ENV['EN_API_KEY'])
+instrument_connection_with_extended_logging(client)
+
+byebug
+
+puts "Bye!"

--- a/lib/engaging_networks_rest.rb
+++ b/lib/engaging_networks_rest.rb
@@ -1,0 +1,9 @@
+require 'engaging_networks_rest/client'
+
+module EngagingNetworksRest
+  class << self
+    def new(api_key:)
+      EngagingNetworksRest::Client.new(api_key: api_key)
+    end
+  end
+end

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -1,0 +1,25 @@
+require 'faraday'
+
+module EngagingNetworksRest
+  class Client
+    attr_reader :api_key, :connection, :ens_auth_key
+
+    ENS_DOMAIN = 'www.e-activist.com'.freeze
+
+    def initialize(api_key:)
+      @api_key = api_key
+
+      @connection = Faraday.new(url: "https://#{ENS_DOMAIN}")
+    end
+
+    def authenticate!
+      response = connection.post do |req|
+        req.url '/ens/service/authenticate'
+        req.headers['Content-Type'] = 'application/json'
+        req.body = api_key
+      end
+
+      @ens_auth_key = response.body
+    end
+  end
+end

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-
+require 'json'
 require 'engaging_networks_rest/client/pages'
 
 module EngagingNetworksRest
@@ -21,7 +21,8 @@ module EngagingNetworksRest
         req.body = api_key
       end
 
-      @ens_auth_key = response.body
+      parsed_body = JSON.parse(response.body)
+      @ens_auth_key = parsed_body['ens-auth-token']
     end
 
     def authenticated?

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -28,6 +28,10 @@ module EngagingNetworksRest
       !ens_auth_key.nil?
     end
 
+    def get(path:, params: {})
+      request(method: :get, path: path, params: params)
+    end
+
     def post(path:, body: {})
       request(method: :post, path: path, body: body)
     end

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -1,5 +1,7 @@
 require 'faraday'
 
+require 'engaging_networks_rest/client/pages'
+
 module EngagingNetworksRest
   class Client
     attr_reader :api_key, :connection, :ens_auth_key
@@ -20,6 +22,34 @@ module EngagingNetworksRest
       end
 
       @ens_auth_key = response.body
+    end
+
+    def authenticated?
+      !ens_auth_key.nil?
+    end
+
+    def post(path:, body: {})
+      request(method: :post, path: path, body: body)
+    end
+
+    include EngagingNetworksRest::Client::Pages
+
+    private
+
+    def request(method:, path:, params: {}, body: {})
+      unless authenticated?
+        authenticate!
+      end
+
+      response = connection.send(method) do |req|
+        req.path = path
+        req.params = params
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['ens-auth-token'] = ens_auth_key
+        req.body = ::JSON.generate(body) unless body.empty?
+      end
+
+      JSON.parse(response.body)
     end
   end
 end

--- a/lib/engaging_networks_rest/client/pages.rb
+++ b/lib/engaging_networks_rest/client/pages.rb
@@ -1,6 +1,15 @@
 module EngagingNetworksRest
   class Client
     module Pages
+      def pages(type:, status: nil)
+        filter_params = {'type' => type}
+        unless status.nil?
+          filter_params['status'] = status
+        end
+
+        get(path: "/ens/service/page", params: filter_params)
+      end
+
       def process_page_request(page_id:, body:)
         post(path: "/ens/service/page/#{page_id}/process", body: body)
       end

--- a/lib/engaging_networks_rest/client/pages.rb
+++ b/lib/engaging_networks_rest/client/pages.rb
@@ -1,0 +1,9 @@
+module EngagingNetworksRest
+  class Client
+    module Pages
+      def process_page_request(page_id:, body:)
+        post(path: "/ens/service/page/#{page_id}/process", body: body)
+      end
+    end
+  end
+end

--- a/lib/engaging_networks_rest/client/pages.rb
+++ b/lib/engaging_networks_rest/client/pages.rb
@@ -10,8 +10,12 @@ module EngagingNetworksRest
         get(path: "/ens/service/page", params: filter_params)
       end
 
-      def process_page_request(page_id:, body:)
-        post(path: "/ens/service/page/#{page_id}/process", body: body)
+      def page(page_id:)
+        get(path: "/ens/service/page/#{page_id}")
+      end
+
+      def process_page_request(page_id:, supporter_data:)
+        post(path: "/ens/service/page/#{page_id}/process", body: {supporter: supporter_data})
       end
     end
   end

--- a/spec/client/pages_spec.rb
+++ b/spec/client/pages_spec.rb
@@ -7,6 +7,50 @@ describe EngagingNetworksRest::Client::Pages do
 
   subject { EngagingNetworksRest::Client.new(api_key: api_key) }
 
+  describe '#pages' do
+    let(:page_type) { 'dcf' }
+    let(:page_status) { 'live' }
+    let(:pages_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/page" }
+
+    # The API docs don't actually say what this response looks like, so this is a guess.
+    # Fortunately, it doesn't actually matter for our purposes, since we just return whatever JSON we get.
+    let(:response) { [{'id' => 123, 'title' => 'A page'}, {'id' => 234, 'title' => 'Another page'}] }
+
+    shared_examples_for 'list pages' do
+      it 'should get pages' do
+        stub_request(:get, pages_url).with(headers: standard_headers, query: {'type' => page_type, 'status' => page_status})
+          .to_return(body: response.to_json)
+
+        expect(subject.pages(type: page_type, status: page_status)).to eq response
+      end
+
+      it 'should omit status param if not specified' do
+        stub_request(:get, pages_url).with(headers: standard_headers, query: {'type' => page_type})
+          .to_return(body: response.to_json)
+
+        expect(subject.pages(type: page_type)).to eq response
+      end
+    end
+
+    context 'not already authenticated' do
+      before :each do
+        expect(subject).to receive(:authenticate!) do
+          allow(subject).to receive(:ens_auth_key).and_return(ens_auth_key)
+        end
+      end
+
+      include_examples 'list pages'
+    end
+
+    context 'already authenticated' do
+      before :each do
+        allow(subject).to receive(:ens_auth_key).and_return(ens_auth_key)
+      end
+
+      include_examples 'list pages'
+    end
+  end
+
   describe '#process_page_request' do
     let(:page_id) { 234 }
     let(:page_req_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/page/#{page_id}/process" }

--- a/spec/client/pages_spec.rb
+++ b/spec/client/pages_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe EngagingNetworksRest::Client::Pages do
+  let(:api_key) { 'abc-123' }
+  let(:ens_auth_key) { 'tmp-auth-key-456' }
+  let(:standard_headers) { {'Content-Type' => 'application/json', 'ens-auth-token' => ens_auth_key} }
+
+  subject { EngagingNetworksRest::Client.new(api_key: api_key) }
+
+  describe '#process_page_request' do
+    let(:page_id) { 234 }
+    let(:page_req_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/page/#{page_id}/process" }
+    let(:email) { Faker::Internet.email }
+    let(:supporter_hash) { {'firstName' => 'Joe', 'lastName' => 'Smith', 'emailAddress' => email, 'customField1' => 'foo'} }
+    let(:response) { {'id' => '1234567', 'status' => 'SUCCESS', 'supporterEmailAddress' => email, 'supporterId' => '98765'} }
+
+    shared_examples_for 'process page request' do
+      it 'should process the page request' do
+        stub_request(:post, page_req_url).with(body: {supporter: supporter_hash}.to_json, headers: standard_headers)
+          .to_return(body: response.to_json)
+
+        expect(subject.process_page_request(page_id: page_id, body: {supporter: supporter_hash})).to eq response
+      end
+    end
+
+    context 'not already authenticated' do
+      before :each do
+        expect(subject).to receive(:authenticate!) do
+          allow(subject).to receive(:ens_auth_key).and_return(ens_auth_key)
+        end
+      end
+
+      include_examples 'process page request'
+    end
+
+    context 'already authenticated' do
+      before :each do
+        allow(subject).to receive(:ens_auth_key).and_return(ens_auth_key)
+      end
+
+      include_examples 'process page request'
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -8,10 +8,11 @@ describe EngagingNetworksRest::Client do
 
   describe '#authenticate!' do
     let(:auth_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/authenticate" }
-    let(:auth_key) { 'temporary-auth-key-456' }
+    let(:auth_key) { '75491e42-99dc-45ce-b637-a681bede875c' }
+    let(:auth_key_body) { "{\"ens-auth-token\":\"#{auth_key}\",\"expires\":3600000}" }
 
     before :each do
-      stub_request(:post, auth_url).with(body: api_key, headers: content_type_header).to_return(body: auth_key)
+      stub_request(:post, auth_url).with(body: api_key, headers: content_type_header).to_return(body: auth_key_body)
     end
 
     it 'should set the ens_auth_key on the client' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe EngagingNetworksRest::Client do
+  let(:api_key) { 'abc123' }
+  let(:content_type_header) { {'Content-Type' => 'application/json'} }
+
+  subject { EngagingNetworksRest::Client.new(api_key: api_key) }
+
+  describe '#authenticate!' do
+    let(:auth_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/authenticate" }
+    let(:auth_key) { 'temporary-auth-key-456' }
+
+    before :each do
+      stub_request(:post, auth_url).with(body: api_key, headers: content_type_header).to_return(body: auth_key)
+    end
+
+    it 'should set the ens_auth_key on the client' do
+      subject.authenticate!
+
+      expect(subject.ens_auth_key).to eq auth_key
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'rspec'
+require 'webmock/rspec'
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
+
+require 'engaging_networks_rest'
+
+RSpec.configure do |config|
+  config.include WebMock::API
+
+  config.before :each do
+    WebMock.reset!
+  end
+
+  config.after :each do
+    WebMock.reset!
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'webmock/rspec'
+require 'faker'
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 


### PR DESCRIPTION
This adds a basic client that can get a list of pages and process page requests.

Not included: Error handling, because the API documentation does not include any information on how errors are returned.