### PR TITLE
Allow overriding the default hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Client gem for the ENS API to Engaging Networks
 ## Usage
 
 ```
-client = EngagingNetworksRest.new(api_key: 'YOUR API KEY HERE')
+client = EngagingNetworksRest.new(api_key: 'YOUR API KEY HERE', host: 'us.engagingnetworks.app')
 
 # get pages by type
 pages = client.pages(type: 'dcf', status: 'live')

--- a/lib/engaging_networks_rest.rb
+++ b/lib/engaging_networks_rest.rb
@@ -4,8 +4,8 @@ require 'engaging_networks_rest/client'
 
 module EngagingNetworksRest
   class << self
-    def new(api_key:)
-      EngagingNetworksRest::Client.new(api_key: api_key)
+    def new(api_key:, host: EngagingNetworksRest::Client::ENS_DOMAIN)
+      EngagingNetworksRest::Client.new(api_key: api_key, host: host)
     end
   end
 end

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -11,10 +11,10 @@ module EngagingNetworksRest
 
     ENS_DOMAIN = 'www.e-activist.com'
 
-    def initialize(api_key:)
+    def initialize(api_key:, host: ENS_DOMAIN)
       @api_key = api_key
 
-      @connection = Faraday.new(url: "https://#{ENS_DOMAIN}") do |conn|
+      @connection = Faraday.new(url: "https://#{host}") do |conn|
         conn.request :json
         conn.response :json, content_type: /\bjson$/
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,7 +9,6 @@ describe EngagingNetworksRest::Client do
   subject { EngagingNetworksRest::Client.new(api_key: api_key) }
 
   describe '#authenticate!' do
-    let(:auth_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/authenticate" }
     let(:auth_key) { '75491e42-99dc-45ce-b637-a681bede875c' }
     let(:auth_key_body) { "{\"ens-auth-token\":\"#{auth_key}\",\"expires\":3600000}" }
 
@@ -19,10 +18,27 @@ describe EngagingNetworksRest::Client do
         .to_return(body: auth_key_body, headers: content_type_header)
     end
 
-    it 'should set the ens_auth_key on the client' do
-      subject.authenticate!
+    context 'with no host specified' do
+      let(:auth_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/authenticate" }
 
-      expect(subject.ens_auth_key).to eq auth_key
+      it 'should set the ens_auth_key on the client' do
+        subject.authenticate!
+
+        expect(subject.ens_auth_key).to eq auth_key
+      end
+    end
+
+    context 'with a host specified' do
+      let(:host) { 'example.com' }
+      let(:auth_url) { "https://#{host}/ens/service/authenticate" }
+
+      subject { EngagingNetworksRest::Client.new(api_key: api_key, host: host) }
+
+      it 'should set the ens_auth_key on the client' do
+        subject.authenticate!
+
+        expect(subject.ens_auth_key).to eq auth_key
+      end
     end
   end
 end


### PR DESCRIPTION
This updates the `EngagingNetworksRest.new` and `EngagingNetworksRest::Client.new` methods to accept an optional `host` parameter. If that parameter is set, network calls will be made to the specified domain name instead of to `www.e-activist.com`.

Not included: Changing the default domain to something more modern, e.g. `ca.engagingnetworks.app`. We'll want to release a new major version for that, since it would be a breaking change for any existing users.