### PR TITLE
Run CI against ruby 3 as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7, 3.0, 3.1, 3.2]
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
@@ -23,11 +23,11 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7, 3.0, 3.1, 3.2]
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,32 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [2.7, 3.0, 3.1, 3.2]
+
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - run: bundle install
       - run: bundle exec rspec
+
   rubocop:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [2.7, 3.0, 3.1, 3.2]
+
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - run: bundle install
       - run: bundle exec rubocop


### PR DESCRIPTION
This updates our CI config so instead of just running against ruby 2.7, it also runs against ruby 3.0, 3.1, and 3.2