### PR TITLE
Require specifying a host when instantiating a Client

### DIFF
--- a/lib/engaging_networks_rest.rb
+++ b/lib/engaging_networks_rest.rb
@@ -4,7 +4,7 @@ require 'engaging_networks_rest/client'
 
 module EngagingNetworksRest
   class << self
-    def new(api_key:, host: EngagingNetworksRest::Client::ENS_DOMAIN)
+    def new(api_key:, host:)
       EngagingNetworksRest::Client.new(api_key: api_key, host: host)
     end
   end

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -9,7 +9,7 @@ module EngagingNetworksRest
   class Client
     attr_reader :api_key, :connection, :ens_auth_key
 
-    ENS_DOMAIN = 'www.e-activist.com'
+    ENS_DOMAIN = 'ca.engagingnetworks.app'
 
     def initialize(api_key:, host: ENS_DOMAIN)
       @api_key = api_key

--- a/lib/engaging_networks_rest/client.rb
+++ b/lib/engaging_networks_rest/client.rb
@@ -9,9 +9,7 @@ module EngagingNetworksRest
   class Client
     attr_reader :api_key, :connection, :ens_auth_key
 
-    ENS_DOMAIN = 'ca.engagingnetworks.app'
-
-    def initialize(api_key:, host: ENS_DOMAIN)
+    def initialize(api_key:, host:)
       @api_key = api_key
 
       @connection = Faraday.new(url: "https://#{host}") do |conn|

--- a/spec/client/pages_spec.rb
+++ b/spec/client/pages_spec.rb
@@ -3,16 +3,17 @@
 require 'spec_helper'
 
 describe EngagingNetworksRest::Client::Pages do
+  let(:host) { 'example.com' }
   let(:api_key) { 'abc-123' }
   let(:ens_auth_key) { 'tmp-auth-key-456' }
   let(:standard_headers) { { 'Content-Type' => 'application/json', 'Ens-Auth-Token' => ens_auth_key } }
 
-  subject { EngagingNetworksRest::Client.new(api_key: api_key) }
+  subject { EngagingNetworksRest::Client.new(api_key: api_key, host: host) }
 
   describe '#pages' do
     let(:page_type) { 'dcf' }
     let(:page_status) { 'live' }
-    let(:pages_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/page" }
+    let(:pages_url) { "https://example.com/ens/service/page" }
 
     # The API docs don't actually say what this response looks like, so this is a guess.
     # Fortunately, it doesn't actually matter for our purposes, since we just return whatever JSON we get.
@@ -61,7 +62,7 @@ describe EngagingNetworksRest::Client::Pages do
 
   describe '#process_page_request' do
     let(:page_id) { 234 }
-    let(:page_req_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/page/#{page_id}/process" }
+    let(:page_req_url) { "https://example.com/ens/service/page/#{page_id}/process" }
     let(:email) { Faker::Internet.email }
     let(:supporter_hash) do
       { 'firstName' => 'Joe', 'lastName' => 'Smith', 'emailAddress' => email, 'customField1' => 'foo' }

--- a/spec/client/pages_spec.rb
+++ b/spec/client/pages_spec.rb
@@ -13,7 +13,7 @@ describe EngagingNetworksRest::Client::Pages do
   describe '#pages' do
     let(:page_type) { 'dcf' }
     let(:page_status) { 'live' }
-    let(:pages_url) { "https://example.com/ens/service/page" }
+    let(:pages_url) { 'https://example.com/ens/service/page' }
 
     # The API docs don't actually say what this response looks like, so this is a guess.
     # Fortunately, it doesn't actually matter for our purposes, since we just return whatever JSON we get.

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,12 +3,14 @@
 require 'spec_helper'
 
 describe EngagingNetworksRest::Client do
+  let(:host) { 'example.com' }
   let(:api_key) { 'abc123' }
   let(:content_type_header) { { 'Content-Type' => 'application/json' } }
 
-  subject { EngagingNetworksRest::Client.new(api_key: api_key) }
+  subject { EngagingNetworksRest::Client.new(api_key: api_key, host: host) }
 
   describe '#authenticate!' do
+    let(:auth_url) { "https://#{host}/ens/service/authenticate" }
     let(:auth_key) { '75491e42-99dc-45ce-b637-a681bede875c' }
     let(:auth_key_body) { "{\"ens-auth-token\":\"#{auth_key}\",\"expires\":3600000}" }
 
@@ -18,27 +20,10 @@ describe EngagingNetworksRest::Client do
         .to_return(body: auth_key_body, headers: content_type_header)
     end
 
-    context 'with no host specified' do
-      let(:auth_url) { "https://#{EngagingNetworksRest::Client::ENS_DOMAIN}/ens/service/authenticate" }
+    it 'should set the ens_auth_key on the client' do
+      subject.authenticate!
 
-      it 'should set the ens_auth_key on the client' do
-        subject.authenticate!
-
-        expect(subject.ens_auth_key).to eq auth_key
-      end
-    end
-
-    context 'with a host specified' do
-      let(:host) { 'example.com' }
-      let(:auth_url) { "https://#{host}/ens/service/authenticate" }
-
-      subject { EngagingNetworksRest::Client.new(api_key: api_key, host: host) }
-
-      it 'should set the ens_auth_key on the client' do
-        subject.authenticate!
-
-        expect(subject.ens_auth_key).to eq auth_key
-      end
+      expect(subject.ens_auth_key).to eq auth_key
     end
   end
 end


### PR DESCRIPTION
This updates the `EngagingNetworksRest::Client.new` and `EngagingNetworksRest.new` methods, making the `host` argument required and removing the default. Since the [API documentation](https://www.engagingnetworks.support/api/rest/#/) lists two supported domains (`ca.engagingnetworks.app` and `us.engagingnetworks.app`), we do not want to assume any given user wants one or the other. It's safest to require the user to specify which host they want.

This is a potentially breaking change for existing users, so it will be included in a 1.0 release.